### PR TITLE
Bug intercepting request with query parameters

### DIFF
--- a/src/commands/intercept-stubs.ts
+++ b/src/commands/intercept-stubs.ts
@@ -83,11 +83,11 @@ function matchRequestUrl(request: StubRequest, matcher: RouteMatcherOptions) {
   if (request.url) {
     matcher.url = request.url;
   } else if (request.urlPath) {
-    matcher.path = request.urlPath;
+    matcher.pathname = request.urlPath;
   } else if (request.urlPattern) {
     matcher.url = matchPattern(request.urlPattern);
   } else if (request.urlPathPattern) {
-    matcher.path = matchPattern(request.urlPathPattern);
+    matcher.pathname = matchPattern(request.urlPathPattern);
   }
 }
 


### PR DESCRIPTION
There is a bug intercepting requests with query parameters. This bug is produced because we are using "path" (meant for HTTP request path after the hostname, including query parameters) instead of "pathname" (Like path, but without query parameters).

See cypress doc here:

https://docs.cypress.io/api/commands/intercept

With this fix it is working fine in my tests.

Thanks!